### PR TITLE
Support for multiple host names and potential null-reference fix.

### DIFF
--- a/Sitemap.Xml/Pipelines/DefaultSitemapXmlProcessor.cs
+++ b/Sitemap.Xml/Pipelines/DefaultSitemapXmlProcessor.cs
@@ -41,6 +41,7 @@ namespace LD.Sitemap.Xml.Pipelines
 
                 var items = results
                     .Select(i => Sitecore.Configuration.Factory.GetDatabase(i.DatabaseName).GetItem(i.ItemId, Sitecore.Globalization.Language.Parse(i.Language), Sitecore.Data.Version.Latest))
+                    .Where(i => i != null) // exclude results that exist in the index but not in the database
                     .ToList();
 
                 var sb = new StringBuilder();

--- a/Sitemap.Xml/SitemapHandler.cs
+++ b/Sitemap.Xml/SitemapHandler.cs
@@ -1,4 +1,5 @@
-﻿using LD.Sitemap.Xml.Pipelines;
+﻿using System;
+using LD.Sitemap.Xml.Pipelines;
 using Sitecore.Pipelines;
 using Sitecore.Xml;
 using System.Linq;
@@ -19,7 +20,10 @@ namespace LD.Sitemap.Xml
                 .Select(node => XmlUtil.GetAttribute("name", node));
 
             var website = Sitecore.Configuration.Factory.GetSiteInfoList()
-                .FirstOrDefault(i => i.HostName.ToLower() == context.Request.Url.Host.ToLower());
+                .FirstOrDefault(i => i.HostName != null &&
+                    i.HostName.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries)
+                        .Any(n => string.Equals(n, context.Request.Url.Host, StringComparison.CurrentCultureIgnoreCase)));
+
             if (website == null || (website.Port > 0 && website.Port != context.Request.Url.Port))
             {
                 context.Response.StatusCode = 404;


### PR DESCRIPTION
Prior to this fix, the system would not locate the <site> entry when the hostName attribute contains multiple values (pipe delimited).  Add support for this scenario.

Additionally, fix a null-reference exception that can occur when the ContentSearch index is out of sync with the database (an entry exists in the index, but not in the database).